### PR TITLE
Feature/#35/message

### DIFF
--- a/src/main/java/dev/be/learnable/core/domain/BotMessage.java
+++ b/src/main/java/dev/be/learnable/core/domain/BotMessage.java
@@ -4,10 +4,8 @@ import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,16 +25,20 @@ public class BotMessage extends BaseEntity {
 
     private String content;
 
+    @Column(length = 1000)
+    private String answer;
+
     private Boolean isBookmarked;
 
-    private BotMessage(ChatRoom chatRoom, String content, Boolean isBookmarked) {
+    private BotMessage(ChatRoom chatRoom, String content, String answer,Boolean isBookmarked) {
         this.chatRoom = chatRoom;
         this.content = content;
+        this.answer = answer;
         this.isBookmarked = isBookmarked;
     }
 
-    public static BotMessage of(ChatRoom chatRoom, String content, Boolean isBookmarked) {
-        return new BotMessage(chatRoom, content, isBookmarked);
+    public static BotMessage of(ChatRoom chatRoom, String content, String answer,Boolean isBookmarked) {
+        return new BotMessage(chatRoom, content, answer ,isBookmarked);
     }
 
     public void updateBookmarked(Boolean bookmarked) {

--- a/src/main/java/dev/be/learnable/core/repository/BotMessageRepository.java
+++ b/src/main/java/dev/be/learnable/core/repository/BotMessageRepository.java
@@ -2,8 +2,16 @@ package dev.be.learnable.core.repository;
 
 import dev.be.learnable.core.domain.BotMessage;
 import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BotMessageRepository extends JpaRepository<BotMessage, Long> {
     List<BotMessage> findBotMessageByChatRoom_Id(Long chatroomId);
+
+    @Query("SELECT b.answer FROM BotMessage b WHERE b.chatRoom.id = :chatRoomId ORDER BY b.id DESC")
+    List<String> findLatestAnswerByChatRoomId(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+
 }

--- a/src/main/java/dev/be/learnable/core/service/BotMessageService.java
+++ b/src/main/java/dev/be/learnable/core/service/BotMessageService.java
@@ -8,6 +8,8 @@ import dev.be.learnable.core.repository.ChatRoomRepository;
 import dev.be.learnable.core.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,8 +32,15 @@ public class BotMessageService {
         Random random = new Random();
         int randomIndex = random.nextInt(questions.size());
         String content = questions.get(randomIndex).getContent();
-        BotMessage botMessage = BotMessage.of(chatRoom,content,false);
+        String answer = questions.get(randomIndex).getAnswer();
+        BotMessage botMessage = BotMessage.of(chatRoom,content, answer,false);
         botMessageRepository.save(botMessage);
         return content;
+    }
+
+    public String getAnswerByQuestion(Long chatRoomId){
+        Pageable pageable = PageRequest.of(0,1);
+        List<String> latestAnswer = botMessageRepository.findLatestAnswerByChatRoomId(chatRoomId,pageable);
+        return latestAnswer.get(0);
     }
 }

--- a/src/main/java/dev/be/learnable/core/web/BotMessageController.java
+++ b/src/main/java/dev/be/learnable/core/web/BotMessageController.java
@@ -1,13 +1,12 @@
 package dev.be.learnable.core.web;
 
 
-import dev.be.learnable.core.dto.response.ChatGPTResponse;
-import dev.be.learnable.core.dto.request.ChatRequest;
 import dev.be.learnable.core.service.BotMessageService;
-import dev.be.learnable.core.service.OpenAIClientService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,4 +22,9 @@ public class BotMessageController {
         return botMessageService.getRandomQuestionBySubject(chatroomId,subjectId);
     }
 
+    // 채팅방 별 가장 최근 질문 정답
+    @GetMapping("{chatroomId}/answers")
+    public String getAnswerByRandomQuestion(@PathVariable Long chatroomId){
+        return botMessageService.getAnswerByQuestion(chatroomId);
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -458,14 +458,18 @@ PUT은 안전하지 않은 수정이 주로 이루어집니다. 즉, 전체 데�
 
 따라서, 전체 데이터를 한 번에 수정하고 안전하지 않은 경우 PUT을 사용합니다. 그러나 일부 필드만 수정하고 안전한 경우 PATCH를 사용합니다.' ,now(), now());
 
--- 채팅방 2개
-insert into chat_room (member_id, subject_id, title, created_at, updated_at) values
-(1, 1, 'chatroom1', now(), now()),
-(1, 2, 'chatroom2', now(), now());
-
+-- 채팅방 6개
+INSERT INTO chat_room (member_id, subject_id, title, created_at, updated_at)
+VALUES
+    (1, 1, '운영체제', now(), now()),
+    (1, 2, '데이터베이스', now(), now()),
+    (1, 3, '컴퓨터구조', now(), now()),
+    (1, 4, '자료구조', now(), now()),
+    (1, 5, '알고리즘', now(), now()),
+    (1, 6, '컴퓨터네트워크', now(), now());
 -- 봇 메시지 1개 (북마크 되어있음)
-insert into bot_message (chat_room_id, content, is_bookmarked, created_at, updated_at) values
-(1, 'bot-message1', true, now(), now());
+insert into bot_message (chat_room_id, content, answer ,is_bookmarked, created_at, updated_at) values
+(1, 'bot-message1', 'answer1' ,true, now(), now());
 
 -- 유저 메시지 1개 (북마크 안되어 있음)
 insert into user_message (chat_room_id, content, is_bookmarked, created_at, updated_at) values


### PR DESCRIPTION
### ❗️ 이슈 번호
Closes #35 




### 📝 작성 내용
- BotMessage
도메인에 answer 필드 추가

- BotMessageRepository
채팅방 번호로 가장 최근에 생성된 질문에 대한 정답을 한개 조회하는 쿼리 추가

- BotMessageService
질문 랜덤 생성 시 BotMessage에 Answer도 같이 저장 / 랜덤 생성된 질문에 대한 정답을 조회하는 코드 추가

- BotMessageController
채팅방 번호로 정답 조회 API 추가

- data.sql
원활한 테스트를 위해 6개의 모든 주제 채팅방 추가



### 💡 참고 내용
BotMessage에 Answer 필드가 추가되었습니다. 작성하신 채팅방 API에 관여하지 않는 걸 확인했으나, 혹시 놓친 부분이 있다면 말씀해주시면 감사합니다 :)
