### PR TITLE
점수 파싱 기능 추가

### DIFF
--- a/src/main/java/dev/be/learnable/core/domain/ChatRoom.java
+++ b/src/main/java/dev/be/learnable/core/domain/ChatRoom.java
@@ -11,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,20 +39,20 @@ public class ChatRoom extends BaseEntity{
 
     private Long totalScore; // 채팅방에서 얻은 점수
 
-    private Double avgScore; // 평균 점수
+    public void updateChatroomInfo(Long answerCnt, Long score) {
+        this.answerCnt = answerCnt + 1;
+        this.totalScore += score;
+    }
 
-    public ChatRoom(Member member, Subject subject, String title, Long answerCnt, Long totalScore,
-        Double avgScore) {
+    public ChatRoom(Member member, Subject subject, String title, Long answerCnt, Long totalScore) {
         this.member = member;
         this.subject = subject;
         this.title = title;
         this.answerCnt = answerCnt;
         this.totalScore = totalScore;
-        this.avgScore = avgScore;
     }
 
-    public static ChatRoom of(Member member, Subject subject, String title, Long answerCnt, Long totalScore,
-        Double avgScore) {
-        return new ChatRoom(member, subject, title, answerCnt, totalScore, avgScore);
+    public static ChatRoom of(Member member, Subject subject, String title, Long answerCnt, Long totalScore) {
+        return new ChatRoom(member, subject, title, answerCnt, totalScore);
     }
 }

--- a/src/main/java/dev/be/learnable/core/domain/ChatRoom.java
+++ b/src/main/java/dev/be/learnable/core/domain/ChatRoom.java
@@ -34,13 +34,24 @@ public class ChatRoom extends BaseEntity{
 
     private String title;
 
-    private ChatRoom(Member member, Subject subject, String title) {
+    private Long answerCnt; // 유저 대답 수
+
+    private Long totalScore; // 채팅방에서 얻은 점수
+
+    private Double avgScore; // 평균 점수
+
+    public ChatRoom(Member member, Subject subject, String title, Long answerCnt, Long totalScore,
+        Double avgScore) {
         this.member = member;
         this.subject = subject;
         this.title = title;
+        this.answerCnt = answerCnt;
+        this.totalScore = totalScore;
+        this.avgScore = avgScore;
     }
 
-    public static ChatRoom of(Member member, Subject subject, String title) {
-        return new ChatRoom(member, subject, title);
+    public static ChatRoom of(Member member, Subject subject, String title, Long answerCnt, Long totalScore,
+        Double avgScore) {
+        return new ChatRoom(member, subject, title, answerCnt, totalScore, avgScore);
     }
 }

--- a/src/main/java/dev/be/learnable/core/dto/ChatRoomDto.java
+++ b/src/main/java/dev/be/learnable/core/dto/ChatRoomDto.java
@@ -16,20 +16,22 @@ public class ChatRoomDto {
     private final Long memberId;
     private final Long subjectId;
     private final String title;
+    private final Long answerCnt; // 유저 대답 수
+    private final Long totalScore; // 채팅방에서 얻은 점수
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
 
-    public static ChatRoomDto of(Long chatroomId,Long memberId, Long subjectId, String title, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        return new ChatRoomDto(chatroomId, memberId, subjectId, title,createdAt, updatedAt);
+    public static ChatRoomDto of(Long chatroomId,Long memberId, Long subjectId, String title,Long answerCnt, Long totalScore, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return new ChatRoomDto(chatroomId, memberId, subjectId, title, answerCnt, totalScore,createdAt, updatedAt);
     }
 
-    public static ChatRoomDto of(Long chatroomId, Long memberId, Long subjectId, String title) {
-        return ChatRoomDto.of(chatroomId, memberId, subjectId, title, null, null);
+    public static ChatRoomDto of(Long chatroomId, Long memberId, Long subjectId, String title, Long answerCnt, Long totalScore) {
+        return ChatRoomDto.of(chatroomId, memberId, subjectId, title, answerCnt, totalScore, null, null);
     }
 
-    public static ChatRoomDto of(Long memberId, Long subjectId, String title) {
-        return ChatRoomDto.of(null, memberId, subjectId, title, null, null);
+    public static ChatRoomDto of(Long memberId, Long subjectId, String title,Long answerCnt, Long totalScore) {
+        return ChatRoomDto.of(null, memberId, subjectId, title, answerCnt, totalScore, null, null);
     }
 
     public static ChatRoomDto from(ChatRoom chatRoom) {
@@ -38,6 +40,8 @@ public class ChatRoomDto {
             chatRoom.getMember().getId(),
             chatRoom.getSubject().getId(),
             chatRoom.getTitle(),
+            chatRoom.getAnswerCnt(),
+            chatRoom.getTotalScore(),
             chatRoom.getCreatedAt(),
             chatRoom.getUpdatedAt()
         );
@@ -49,8 +53,7 @@ public class ChatRoomDto {
             subject,
             title,
             0L,
-            0L,
-            0.0
+            0L
         );
     }
 }

--- a/src/main/java/dev/be/learnable/core/dto/ChatRoomDto.java
+++ b/src/main/java/dev/be/learnable/core/dto/ChatRoomDto.java
@@ -47,7 +47,10 @@ public class ChatRoomDto {
         return ChatRoom.of(
             member,
             subject,
-            title
+            title,
+            0L,
+            0L,
+            0.0
         );
     }
 }

--- a/src/main/java/dev/be/learnable/core/dto/request/ChatRoomRequest.java
+++ b/src/main/java/dev/be/learnable/core/dto/request/ChatRoomRequest.java
@@ -22,7 +22,9 @@ public class ChatRoomRequest {
         return ChatRoomDto.of(
             memberId,
             subjectId,
-            title
+            title,
+            0L,
+            0L
         );
     }
 }

--- a/src/main/java/dev/be/learnable/core/dto/response/ChatRoomResponse.java
+++ b/src/main/java/dev/be/learnable/core/dto/response/ChatRoomResponse.java
@@ -12,10 +12,12 @@ public class ChatRoomResponse {
     private final Long memberId;
     private final Long subjectId;
     private final String title;
+    private final Long answerCnt; // 유저 대답 수
+    private final Long totalScore; // 채팅방에서 얻은 점수
     private final LocalDateTime createdAt;
 
-    public static ChatRoomResponse of(Long chatroomId, Long memberId, Long subjectId, String title, LocalDateTime createdAt) {
-        return new ChatRoomResponse(chatroomId, memberId, subjectId, title, createdAt);
+    public static ChatRoomResponse of(Long chatroomId, Long memberId, Long subjectId, String title, Long answerCnt, Long totalScore, LocalDateTime createdAt) {
+        return new ChatRoomResponse(chatroomId, memberId, subjectId, title, answerCnt, totalScore, createdAt);
     }
 
     public static ChatRoomResponse from(ChatRoomDto chatRoomDto) {
@@ -24,6 +26,8 @@ public class ChatRoomResponse {
             chatRoomDto.getMemberId(),
             chatRoomDto.getSubjectId(),
             chatRoomDto.getTitle(),
+            chatRoomDto.getAnswerCnt(),
+            chatRoomDto.getTotalScore(),
             chatRoomDto.getCreatedAt()
         );
     }

--- a/src/main/java/dev/be/learnable/core/web/UserMessageController.java
+++ b/src/main/java/dev/be/learnable/core/web/UserMessageController.java
@@ -2,7 +2,10 @@ package dev.be.learnable.core.web;
 
 import dev.be.learnable.core.dto.request.ChatRequest;
 import dev.be.learnable.core.dto.response.ChatGPTResponse;
+import dev.be.learnable.core.service.ChatRoomService;
 import dev.be.learnable.core.service.OpenAIClientService;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,8 +15,9 @@ import org.springframework.web.bind.annotation.*;
 public class UserMessageController {
 
     private final OpenAIClientService openAIClientService;
+    private final ChatRoomService chatRoomService;
 
-    // GPT 에게 유저 응답 질문
+    // GPT 에게 유저가 질문
     @PostMapping(value = "/chat")
     public String sendQuestion(@RequestBody ChatRequest chatRequest, @RequestParam Long chatroomId){
         ChatGPTResponse response = openAIClientService.chat(chatRequest,chatroomId);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -459,14 +459,14 @@ PUT은 안전하지 않은 수정이 주로 이루어집니다. 즉, 전체 데�
 따라서, 전체 데이터를 한 번에 수정하고 안전하지 않은 경우 PUT을 사용합니다. 그러나 일부 필드만 수정하고 안전한 경우 PATCH를 사용합니다.' ,now(), now());
 
 -- 채팅방 6개
-INSERT INTO chat_room (member_id, subject_id, title, created_at, updated_at)
+INSERT INTO chat_room (member_id, subject_id, title, answer_cnt, total_score, created_at, updated_at)
 VALUES
-    (1, 1, '운영체제', now(), now()),
-    (1, 2, '데이터베이스', now(), now()),
-    (1, 3, '컴퓨터구조', now(), now()),
-    (1, 4, '자료구조', now(), now()),
-    (1, 5, '알고리즘', now(), now()),
-    (1, 6, '컴퓨터네트워크', now(), now());
+    (1, 1, '운영체제', 0, 0, now(), now()),
+    (1, 2, '데이터베이스', 0, 0, now(), now()),
+    (1, 3, '컴퓨터구조', 0, 0,now(), now()),
+    (1, 4, '자료구조', 0, 0,now(), now()),
+    (1, 5, '알고리즘', 0, 0,now(), now()),
+    (1, 6, '컴퓨터네트워크', 0, 0,now(), now());
 -- 봇 메시지 1개 (북마크 되어있음)
 insert into bot_message (chat_room_id, content, answer ,is_bookmarked, created_at, updated_at) values
 (1, 'bot-message1', 'answer1' ,true, now(), now());

--- a/src/test/java/dev/be/learnable/core/service/ChatRoomServiceTest.java
+++ b/src/test/java/dev/be/learnable/core/service/ChatRoomServiceTest.java
@@ -169,7 +169,9 @@ class ChatRoomServiceTest {
         ChatRoom chatRoom = ChatRoom.of(
             createMember(1L),
             createSubject(1L),
-            "title"
+            "title",
+            0L,
+            0L
         );
         ReflectionTestUtils.setField(chatRoom, "id", chatroomId);
         return chatRoom;
@@ -225,6 +227,8 @@ class ChatRoomServiceTest {
             1L,
             1L,
             "test-title",
+            0L,
+            0L,
             LocalDateTime.now(),
             LocalDateTime.now()
         );


### PR DESCRIPTION
### ❗️ 이슈 번호
Closes #34 




### 📝 작성 내용

gpt 응답으로 온 문자열에서 가장 작은 "?점"으로 채팅방 점수에 더해주도록 하였습니다.

ex)
10점 중에서 5점입니다. -> 5점이 추가됩니다.
5점 입니다.  -> 5점이 추가됩니다.
4~7점입니다. -> 7점이 추가됩니다.
4점~7점입니다. -> 4점이 추가됩니다. -> 구간으로 주어지는 경우에는... 회의가 필요할 것 같습니다


